### PR TITLE
Ingore contents of hidden (dot) directories

### DIFF
--- a/lib/express-load.js
+++ b/lib/express-load.js
@@ -57,14 +57,14 @@ ExpressLoad.prototype.then = function(location) {
         var allow = true
           , script = path.join(entity, dir[file]);
 
-        if (fs.statSync(script).isDirectory()) {
-          this.then(path.join(location, dir[file]));
-          allow = false;
-        }
-
         if (dir[file].charAt(0) === '.') {
           this.__log('Ignoring hidden entity: ' + dir[file], 'warn');
 
+          allow = false;
+        }
+
+        if (allow && fs.statSync(script).isDirectory()) {
+          this.then(path.join(location, dir[file]));
           allow = false;
         }
 


### PR DESCRIPTION
Skip recursive loading of hidden directories. Also fixed a logging bug.
Works for my needs (.svn folder with many files inside), but not thoroughly tested.
