### PR TITLE
More flexible module loading

### DIFF
--- a/lib/express-load.js
+++ b/lib/express-load.js
@@ -188,7 +188,7 @@ ExpressLoad.prototype.into = function(instance) {
       , map = [];
 
     if (typeof mod === 'function') {
-      mod = mod(instance);
+      mod = mod.apply(script, arguments);
     }
 
     ns[script.name] = mod;


### PR DESCRIPTION
This tiny fix adds the ability to pass any number of context variables to a module during loading. 

For example, let's say I'd like to add a path prefix in Express:

``` javascript

module.exports = function(app, namespace) {

  var controller = this;

  exports.index = function(req, res) {
    res.locals.controller_name = controller.name;
    res.render('index');
  };

  app.namespace(namespace + '/' + controller.name, function() {
    app.get('/', exports.index);
    app.get('/other', exports.other);
  });

}
```
