### PR TITLE
Added file extension check by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ See the verbose example in the examples folder.
 
 _express-load_ will ignore hidden files and folders (by leading period) unless you explicitly define them to be loaded.
 
-_express-load_ will only load files ending with .js extension unless you explicitly define all files to be loaded (by setting checkext option to false) :
+_express-load_ will by default only load files ending with .js or .node extensions, unless you set checkext option to false : no file extension check at all. You can also change the list of allowed extension (in extlist option).
 
 ```js
-load('controllers', {checkext:false}).into(app);
+load('controllers', {checkext:true, extlist:['.js','.myextension']}).into(app);
 ```
 
 ### Nested Folders

--- a/lib/express-load.js
+++ b/lib/express-load.js
@@ -29,7 +29,9 @@ var title   = 'express-load'
  */
 
 var ExpressLoad = function(entity, options) {
-  this.options = options || { checkext: true };
+  this.options = options || {}
+  if(this.options.checkext === undefined) { this.options.checkext=true;}
+  if(this.options.extlist === undefined) { this.options.extlist=['.js','.node']; }
   this.scripts = [];
   this.then(entity);
 
@@ -74,8 +76,8 @@ ExpressLoad.prototype.then = function(location) {
           }
         }
 
-        if(this.options.checkext && (path.extname(dir[file]) !== '.js')) {
-          this.__log('Ignoring non js file: ' + dir[file], 'warn');
+        if(this.options.checkext && (this.options.extlist.indexOf(path.extname(dir[file]))==-1)) {
+          this.__log('Ignoring file: extension not allowed ' + dir[file], 'warn');
           allow = false;
         }
 


### PR DESCRIPTION
Hello

I had some trouble debugging good code until i figured that express-load was loading my .js files AND emacs backup .js~ files ! express-load does not check file extensions... this is (at least for me) a big problem, as i have other files (todos, docs, .old, .v1...) in directories, and i think that can be a problem for other people using it ?..?

So I added file a extension check by default, with an option (checkext) to get both behaviours... maybe not having extension check by default could be better to keep old behaviour ? 

Cheers

JMB
