### PR TITLE
change context for loaded functions

### DIFF
--- a/lib/express-load.js
+++ b/lib/express-load.js
@@ -205,7 +205,7 @@ ExpressLoad.prototype.into = function(instance) {
       , map = [];
 
     if (typeof mod === 'function') {
-      mod = mod.apply(script, arguments);
+      mod = mod.apply(instance, arguments);
     }
 
     ns[script.name] = mod;


### PR DESCRIPTION
I think it's more useful to have `instance` as `this` inside a function instead of information about file
