### PR TITLE
`base` parameter

### DIFF
--- a/lib/express-load.js
+++ b/lib/express-load.js
@@ -145,7 +145,7 @@ function createNamespace(parent, parts) {
  */
 
 function getName(script) {
-  var script = path.basename(script, path.extname(script)).replace(/[^a-zA-Z0-9]/g, '.')
+  var script = path.basename(script, path.extname(script)).replace(/[^a-zA-Z0-9_]/g, '.')
     , parts = script.split('.')
     , name = parts.shift();
 


### PR DESCRIPTION
As `__getEntity` uses `path.resolve()` it is sensible to working directory. In this case

``` js
// /root/etc/dir/need_this.js
exports = {test: 123}

// /root/index.js
require('./etc/config')

// /root/etc/config.js
var load = require('express-load')
var tgt = {}
load('./dir').into(tgt) // not working, 'cause looking for /root/dir/need_this.js
load(__dirname + '/dir').into(tgt) // works but crazy:
console.log(tgt)
// { '': { 'root': { 'etc': { 'dir': {'need_this': {'test': 123}}}}}}

// use base:
load(__dirname + '/dir/', true ).into(tgt)
// {'need_this': {'test': 123}}
// true is same as we use first

load(__dirname + '/dir/', '/root/etc' ).into(tgt)
// { 'dir': {'need_this': {'test': 123}}}
```

fix is fully back-compatible
