### PR TITLE
Append require.extensions to extlist defaults

### DIFF
--- a/lib/express-load.js
+++ b/lib/express-load.js
@@ -24,8 +24,14 @@ var title   = 'express-load';
  *	Defaults.
  */
 
-var extlist = ['.js', '.node', '.json', '.coffee', '.sjs'];
-var checkext = true;
+var checkext = true
+  , extlist = ['.js', '.node', '.json', '.coffee', '.sjs'];
+
+for (var ext in require.extensions) {
+  if (require.extensions.hasOwnProperty(ext) && extlist.indexOf(ext) === -1) {
+    extlist.push(ext);
+  }
+}
 
 /**
  *  ExpressLoad constructor.


### PR DESCRIPTION
It seems like a good idea to append extensions found on require.extensions to exlist, this allows requiring modules like `js-yaml` right before `express-load` to load yml files also.
