### PR TITLE
delete require cache when reload

### DIFF
--- a/lib/express-load.js
+++ b/lib/express-load.js
@@ -215,6 +215,7 @@ ExpressLoad.prototype.into = function(instance, done) {
 
   var self = this;
   async.eachSeries(this.scripts, function (script, next) {
+    delete require.cache[script.fullpath];
     var parts = script.location.split(path.sep)
       , maps = parts.slice(0)
       , ns = createNamespace(instance, parts)


### PR DESCRIPTION
I think we should delete require cache when load files, especially when watch file changing and reload, this is my case.
