### PR TITLE
Allowing the ability to autoload subdirectories with the same name as a file, if the file being exported is a function.

### DIFF
--- a/lib/express-load.js
+++ b/lib/express-load.js
@@ -236,13 +236,16 @@ ExpressLoad.prototype.into = function(instance, done) {
       , map = [];
 
     var notAsync = typeof mod !== 'function' || mod.length < 2;
-    if (!notAsync) {
-      mod = mod.call(script, instance, function () {
-        self.__log('Loaded *.' + map.join('.'));
-        next();
-      });
-    } else if (typeof mod === 'function') {
-      mod = mod.call(script, instance);
+
+    if (self.options.invoke !== false) {
+      if (!notAsync) {
+        mod = mod.call(script, instance, function () {
+          self.__log('Loaded *.' + map.join('.'));
+          next();
+        });
+      } else if (typeof mod === 'function') {
+        mod = mod.call(script, instance);
+      }
     }
 
     ns[script.name] = mod;

--- a/lib/express-load.js
+++ b/lib/express-load.js
@@ -70,6 +70,7 @@ ExpressLoad.prototype.then = function(location) {
 
   var loc = this.options.cwd ? path.join(this.options.cwd, location) : location;
   var entity = this.__getEntity(loc);
+  var queue = [];
 
   if (entity) {
     if (fs.statSync(entity).isDirectory()) {
@@ -93,7 +94,7 @@ ExpressLoad.prototype.then = function(location) {
         }
 
         if (allow && fs.statSync(script).isDirectory()) {
-          this.then(path.join(location, dir[file]));
+          queue.push(this.then.bind(this, path.join(location, dir[file])));
           allow = false;
         }
 
@@ -118,6 +119,13 @@ ExpressLoad.prototype.then = function(location) {
           });
         }
 
+      }
+
+      // If we have directories in queue to process, then process them now.
+      if (queue.length) {
+        for (var index in queue) {
+          queue[index]();
+        }
       }
     } else {
       var location = path.dirname(location)


### PR DESCRIPTION
Reference: https://github.com/jarradseers/express-load/issues/34

Example:

*File System:*
```
/test/
/test/test2.js
/test.js
```

*test2.js*
```javascript
module.exports = function() {
  return 'test2';
};
```

*test.js*
```javascript
module.exports = function() {
  return function() {
    // code here
  };
};
```

*Accessible Endpoints:*
```javascript
console.log(global.test);
// [Function]

console.log(global.test.test2);
// test2
```
