### PR TITLE
Fix express-load when using ES6 classes

### DIFF
--- a/lib/express-load.js
+++ b/lib/express-load.js
@@ -238,7 +238,7 @@ ExpressLoad.prototype.into = function(instance, done) {
           next();
         });
       } else if (typeof mod === 'function') {
-        // Instance it as function os class
+        // Instance it as function or class
         try {
           mod = mod.call(script, instance);
         } catch(e) {

--- a/lib/express-load.js
+++ b/lib/express-load.js
@@ -238,7 +238,17 @@ ExpressLoad.prototype.into = function(instance, done) {
           next();
         });
       } else if (typeof mod === 'function') {
-        mod = mod.call(script, instance);
+        // Instance it as function os class
+        try {
+          mod = mod.call(script, instance);
+        } catch(e) {
+          // If the error is a TypeError, try to call it as a class constructor
+          if (e.name === 'TypeError') {
+            mod = new mod(instance);
+          } else {
+            throw e;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Hello @jarradseers, 

My team use express-load in a project and was unable to use it together with ES6 classes.
I created the PR and fix it by myself and would be happy if you can check it and release the fix. 

Cheers, 
Felipe

P.s.: although I see your efforts are on consign now, there are some issues in consign that makes it not work in our environment, I've opened some issues and a PR on consign last year in order to migrate.